### PR TITLE
feat: 지난 일기 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/greeenai/greeenai/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/greeenai/greeenai/domain/diary/controller/DiaryController.java
@@ -8,6 +8,7 @@ import com.greeenai.greeenai.domain.diary.dto.response.DiaryWithQuestionsAndAnsw
 import com.greeenai.greeenai.domain.diary.dto.response.DiaryWithQuestionsResponse;
 import com.greeenai.greeenai.domain.diary.service.DiaryService;
 import jakarta.validation.Valid;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +20,12 @@ import org.springframework.web.bind.annotation.*;
 public class DiaryController {
 
     private final DiaryService diaryService;
+
+    @GetMapping
+    public ResponseEntity<List<DiaryResponse>> getMyDiaries(@RequestParam(required = false) LocalDate entryDate) {
+        List<DiaryResponse> responses = diaryService.findAllMyDiaries(entryDate);
+        return ResponseEntity.ok(responses);
+    }
 
     @PostMapping
     public ResponseEntity<DiaryWithQuestionsResponse> createDiary(@Valid @ModelAttribute DiaryCreateRequest request) {
@@ -34,7 +41,7 @@ public class DiaryController {
 
     @GetMapping("/{diaryId}/download-url")
     public ResponseEntity<String> getDiaryDownloadUrl(@PathVariable Long diaryId) {
-        String downloadUrl = diaryService.findDiaryDownloadUrlById(diaryId);
+        String downloadUrl = diaryService.getDownloadUrlByDiaryId(diaryId);
         return ResponseEntity.ok(downloadUrl);
     }
 

--- a/src/main/java/com/greeenai/greeenai/domain/diary/dto/response/DiaryResponse.java
+++ b/src/main/java/com/greeenai/greeenai/domain/diary/dto/response/DiaryResponse.java
@@ -3,8 +3,8 @@ package com.greeenai.greeenai.domain.diary.dto.response;
 import com.greeenai.greeenai.domain.diary.domain.Diary;
 import java.time.LocalDate;
 
-public record DiaryResponse(Long id, String content, LocalDate entryDate) {
-    public static DiaryResponse from(Diary diary) {
-        return new DiaryResponse(diary.getId(), diary.getContent(), diary.getEntryDate());
+public record DiaryResponse(Long id, String content, String imageUrl, LocalDate entryDate) {
+    public static DiaryResponse of(Diary diary, String imageUrl) {
+        return new DiaryResponse(diary.getId(), diary.getContent(), imageUrl, diary.getEntryDate());
     }
 }

--- a/src/main/java/com/greeenai/greeenai/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/greeenai/greeenai/domain/diary/repository/DiaryRepository.java
@@ -1,6 +1,12 @@
 package com.greeenai.greeenai.domain.diary.repository;
 
 import com.greeenai.greeenai.domain.diary.domain.Diary;
+import com.greeenai.greeenai.domain.member.domain.Member;
+import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface DiaryRepository extends JpaRepository<Diary, Long> {}
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    List<Diary> findAllByMemberAndEntryDate(Member member, LocalDate entryDate);
+}

--- a/src/main/java/com/greeenai/greeenai/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/greeenai/greeenai/domain/diary/service/DiaryService.java
@@ -18,6 +18,8 @@ import com.greeenai.greeenai.domain.image.service.ImageService;
 import com.greeenai.greeenai.domain.member.domain.Member;
 import com.greeenai.greeenai.global.error.exception.CustomException;
 import com.greeenai.greeenai.global.util.MemberUtil;
+import jakarta.annotation.Nullable;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -38,11 +40,12 @@ public class DiaryService {
     @Transactional(readOnly = true)
     public DiaryResponse findDiaryById(Long diaryId) {
         Diary diary = diaryRepository.findById(diaryId).orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
-        return DiaryResponse.from(diary);
+        String imageUrl = imageService.getUrl(diary.getImage());
+        return DiaryResponse.of(diary, imageUrl);
     }
 
     @Transactional(readOnly = true)
-    public String findDiaryDownloadUrlById(Long diaryId) {
+    public String getDownloadUrlByDiaryId(Long diaryId) {
         Diary diary = diaryRepository.findById(diaryId).orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
         return imageService.getUrl(diary.getImage());
     }
@@ -100,5 +103,18 @@ public class DiaryService {
         if (!currentMemberId.equals(diaryOwnerId)) {
             throw new CustomException(DIARY_OWNER_MISMATCH);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public List<DiaryResponse> findAllMyDiaries(@Nullable LocalDate entryDate) {
+        Member currentMember = memberUtil.getCurrentMember();
+        List<Diary> myDiaries = diaryRepository.findAllByMemberAndEntryDate(currentMember, entryDate);
+
+        return myDiaries.stream()
+                .map(diary -> {
+                    String imageUrl = imageService.getUrl(diary.getImage());
+                    return DiaryResponse.of(diary, imageUrl);
+                })
+                .toList();
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈
- close #50

## 📌 작업 내용 및 특이사항
- 지난 일기 목록 조회 API 구현했습니다.
- DiaryResponse에 imageUrl이 포함 되어야 할텐데 없어서 추가했습니다.

## 📝 참고사항
-

## 📚 기타
-
