### PR TITLE
chore: Querydsl 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,12 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Querydsl
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 test {

--- a/src/main/java/com/greeenai/greeenai/global/config/QuerydslConfig.java
+++ b/src/main/java/com/greeenai/greeenai/global/config/QuerydslConfig.java
@@ -1,0 +1,18 @@
+package com.greeenai.greeenai.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}


### PR DESCRIPTION
## 🌱 관련 이슈
- close #63

## 📌 작업 내용 및 특이사항
- 지난 일기 목록 조회 시 쿼리 파라미터로 entryDate를 제공합니다. entryDate는 required 필드가 아니므로 동적인 처리가 필요합니다.
- 이 과정에서 동적인 쿼리 처리가 가능하도록, QueryDSL을 도입합니다.

## 📝 참고사항
-

## 📚 기타
-
